### PR TITLE
Fixed "parameter 1 is not of type 'Node'"

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,20 @@ function validate(binding) {
 }
 
 function isPopup(popupItem, elements) {
-  if (!popupItem || !elements) 
+  if (!popupItem || !elements)
     return false
 
   for (var i = 0, len = elements.length; i < len; i++) {
-    if (popupItem.contains(elements[i])) 
-      return true
-    if (elements[i].contains(popupItem))
-      return false
+    try {
+      if (popupItem.contains(elements[i])) {
+        return true
+      }
+      if (elements[i].contains(popupItem)) {
+        return false
+      }
+    } catch(e) {
+      return false;
+    }
   }
 
   return false


### PR DESCRIPTION
Fixed Uncaught TypeError: Failed to execute 'contains' on 'Node': parameter 1 is not of type 'Node'.